### PR TITLE
switch to master branch of discord.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "youtube-audio-stream": "^0.0.13",
     "ytdl-core": "^0.7.6",
-    "discord.js": "hydrabolt/discord.js#rewrite"
+    "discord.js": "hydrabolt/discord.js#master"
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
now that hydra has destroyed the rewrite branch and merged it into the master branch, that should probably be used instead.
